### PR TITLE
[feature] Add support for left joins

### DIFF
--- a/packages/core/async.ts
+++ b/packages/core/async.ts
@@ -111,6 +111,12 @@ export class AsyncIterableWrapper<T, TNext = any> {
     return collectAsync(this.iterable)
   }
 
+  filter<S extends T>(
+    predicate: (item: T) => item is S,
+  ): AsyncIterableWrapper<S, TNext>
+  filter(
+    predicate: (item: T) => Promisable<boolean>,
+  ): AsyncIterableWrapper<T, TNext>
   filter(
     predicate: (item: T) => Promisable<boolean>,
   ): AsyncIterableWrapper<T, TNext> {

--- a/packages/core/query/QueryPlanNode.test.ts
+++ b/packages/core/query/QueryPlanNode.test.ts
@@ -367,6 +367,38 @@ Deno.test("QueryBuilder (INNER) JOINS", async () => {
   ])
 })
 
+Deno.test("QueryBuilder LEFT JOINS", async () => {
+  const { db } = await init()
+
+  const cats = await db.query(
+    dbSchema.query()
+      .from("cats")
+      .leftJoin(
+        "catOwners",
+        (t) => t.column("cats", "id").eq(t.column("catOwners", "petId")),
+      )
+      .leftJoin(
+        "humans",
+        (t) => t.column("humans.id").eq(t.column("catOwners.ownerId")),
+      )
+      .select({
+        catName: (t) => t.column("cats.name"),
+        owner: (t) => t.column("humans.firstName"),
+      }),
+  ).toArray()
+
+  expect(cats).toEqual([
+    { catName: "fluffy", owner: "Alice" },
+    { catName: "fluffy", owner: "Bob" },
+    { catName: "mittens", owner: "Bob" },
+    { catName: "Mr. Blue", owner: null },
+  ])
+
+  assertTrue<
+    TypeEquals<Array<{ catName: string; owner: string | null }>, typeof cats>
+  >()
+})
+
 Deno.test("QueryBuilder .in()", async () => {
   const { db } = await init()
   const plan = dbSchema.query()

--- a/packages/core/query/QueryPlanNode.test.ts
+++ b/packages/core/query/QueryPlanNode.test.ts
@@ -40,16 +40,20 @@ const dbSchema = s.db().withTables(
 async function init() {
   const db = await PaulDB.inMemory()
   const model = await db.dbFile.getDBModel(dbSchema)
-  await model.cats.insert({ name: "fluffy", age: 3, id: 1 })
-  await model.cats.insert({ name: "mittens", age: 5, id: 2 })
-  await model.humans.insertMany([
-    { firstName: "Alice", lastName: "Smith", id: 1 },
-    { firstName: "Bob", lastName: "Jones", id: 2 },
+  const [fluffy, mittens, _mrBlue] = await model.cats.insertManyAndReturn([
+    { name: "fluffy", age: 3 },
+    { name: "mittens", age: 5 },
+    { name: "Mr. Blue", age: 16 },
+  ])
+  const [alice, bob, _charlie] = await model.humans.insertManyAndReturn([
+    { firstName: "Alice", lastName: "Smith" },
+    { firstName: "Bob", lastName: "Jones" },
+    { firstName: "Charlie", lastName: "Brown" },
   ])
   await model.catOwners.insertMany([
-    { petId: 1, ownerId: 1 },
-    { petId: 1, ownerId: 2 },
-    { petId: 2, ownerId: 2 },
+    { petId: fluffy.id, ownerId: alice.id },
+    { petId: fluffy.id, ownerId: bob.id },
+    { petId: mittens.id, ownerId: bob.id },
   ])
   return { model, db }
 }
@@ -111,6 +115,7 @@ Deno.test("QueryPlanNode", async () => {
   expect(oldOrFluffyCats).toEqual([
     { cats: { id: 1, name: "fluffy", age: 3, likesTreats: true } },
     { cats: { id: 2, name: "mittens", age: 5, likesTreats: true } },
+    { cats: { id: 3, name: "Mr. Blue", age: 16, likesTreats: true } },
   ])
 
   // types flow through the query builder API:
@@ -174,7 +179,7 @@ Deno.test("QueryPlanNode Aggregates", async () => {
     "$0",
   )
   expect(await plan.execute(db).toArray()).toEqual([
-    { "$0": { count: 2, max: 5 } },
+    { "$0": { count: 3, max: 16 } },
   ])
 })
 
@@ -335,7 +340,7 @@ Deno.test("TypeTools", () => {
   >()
 })
 
-Deno.test("QueryBuilder JOINS", async () => {
+Deno.test("QueryBuilder (INNER) JOINS", async () => {
   const { db } = await init()
 
   const cats = await db.query(
@@ -360,34 +365,10 @@ Deno.test("QueryBuilder JOINS", async () => {
     { catName: "fluffy", owner: "Bob" },
     { catName: "mittens", owner: "Bob" },
   ])
-
-  const plan = dbSchema.query()
-    .from("cats")
-    .join(
-      "catOwners",
-      (t) => t.column("cats.id").eq(t.column("catOwners.petId")),
-    )
-    .join(
-      "humans",
-      (t) => t.column("catOwners.ownerId").eq(t.column("humans.id")),
-    )
-    .select({
-      name: (t) => t.column("cats.name"),
-      ownerId: (t) => t.column("catOwners.ownerId"),
-      ownerName: (t) => t.column("humans.firstName"),
-    })
-    .plan()
-
-  expect(await plan.execute(db).toArray()).toEqual([
-    { "$0": { name: "fluffy", ownerId: 1, ownerName: "Alice" } },
-    { "$0": { name: "fluffy", ownerId: 2, ownerName: "Bob" } },
-    { "$0": { name: "mittens", ownerId: 2, ownerName: "Bob" } },
-  ])
 })
 
 Deno.test("QueryBuilder .in()", async () => {
-  const { db, model } = await init()
-  await model.cats.insert({ name: "Mr. Blue", age: 3, id: 3 })
+  const { db } = await init()
   const plan = dbSchema.query()
     .from("cats")
     .where((t) => t.column("cats", "name").in("fluffy", "Mr. Blue"))
@@ -403,8 +384,7 @@ Deno.test("QueryBuilder .in()", async () => {
 })
 
 Deno.test("QueryBuilder .not()", async () => {
-  const { db, model } = await init()
-  await model.cats.insert({ name: "Mr. Blue", age: 3, id: 3 })
+  const { db } = await init()
   const plan = dbSchema.query()
     .from("cats")
     .where((t) => t.column("cats", "name").eq("fluffy").not())
@@ -446,11 +426,11 @@ Deno.test("QueryBuilder .aggregate()", async () => {
   expect(data).toEqual([
     {
       "$0": {
-        count: 2,
-        maxAge: 5,
+        count: 3,
+        maxAge: 16,
         maxName: "mittens",
-        minName: "fluffy",
-        totalAge: 8,
+        minName: "Mr. Blue",
+        totalAge: 24,
       },
     },
   ])
@@ -495,6 +475,7 @@ Deno.test("QueryBuilder subqueries", async () => {
   expect(data).toEqual([
     { "$0": { name: "Alice", numCats: 1 } },
     { "$0": { name: "Bob", numCats: 2 } },
+    { "$0": { name: "Charlie", numCats: 0 } },
   ])
   assertTrue<
     TypeEquals<

--- a/packages/core/query/QueryPlanNode.ts
+++ b/packages/core/query/QueryPlanNode.ts
@@ -197,7 +197,7 @@ export class Aggregate<T extends UnknownRecord, AliasT extends string>
       accumulator = await aggregation.update(accumulator, ctx.withRowData(row))
     }
     return new AsyncIterableWrapper([
-      { [this.alias]: accumulator as T } as Record<AliasT, T>,
+      { [this.alias]: aggregation.result(accumulator) } as Record<AliasT, T>,
     ])
   }
 }
@@ -326,7 +326,9 @@ export class GroupBy<
         }
       }
       for (const { groupKey, accumulator } of groups) {
-        yield { [alias]: { ...groupKey, ...accumulator } } as Record<
+        yield {
+          [alias]: { ...groupKey, ...aggregation.result(accumulator) },
+        } as Record<
           AliasT,
           GroupKey & AggregateT
         >

--- a/packages/core/schema/TableSchema.ts
+++ b/packages/core/schema/TableSchema.ts
@@ -93,6 +93,22 @@ export interface ISchema<
   readonly columnsByName: ColumnsT
 }
 
+/**
+ * Makes all the columns in a column record nullable
+ */
+export type NullableColumnRecord<T extends ColumnRecord> = {
+  [K in keyof T]: Column.MakeNullable<T[K]>
+}
+
+/**
+ * Makes all the columns in a schema nullable
+ */
+export type NullableSchema<T extends ISchema> = T extends ISchema<
+  infer TName,
+  infer ColumnsT
+> ? ISchema<TName, NullableColumnRecord<ColumnsT>>
+  : never
+
 export class TableSchema<
   TableName extends string,
   ColumnSchemasT extends StoredColumnRecord,

--- a/packages/core/schema/columns/Computed.ts
+++ b/packages/core/schema/columns/Computed.ts
@@ -25,6 +25,18 @@ export type Any<
 }
 
 /**
+ * Converts a computed column type to a nullable type
+ */
+export type MakeNullable<C extends Any> = C extends Any<
+  infer Name,
+  infer Unique,
+  infer Indexed,
+  infer Input,
+  infer Output
+> ? Any<Name, Unique, Indexed, Input | null, Output | null>
+  : never
+
+/**
  * Infer the output type of a computed column
  */
 export type GetOutput<C> = C extends

--- a/packages/core/schema/columns/Stored.ts
+++ b/packages/core/schema/columns/Stored.ts
@@ -44,6 +44,18 @@ export type Simple<Name extends string = string, ValueT = any> = Any<
 >
 
 /**
+ * Converts a stored column type to a nullable stored column type
+ */
+export type MakeNullable<C extends Any> = C extends Any<
+  infer Name,
+  infer Value,
+  infer Unique,
+  infer Indexed,
+  infer DefaultValueFactory
+> ? Any<Name, Value | null, Unique, Indexed, DefaultValueFactory>
+  : never
+
+/**
  * Represents any stored column with a default value
  */
 export type WithDefaultValue<ValueT = unknown> = OverrideProperties<

--- a/packages/core/schema/columns/index.ts
+++ b/packages/core/schema/columns/index.ts
@@ -54,3 +54,11 @@ export type GetRecordContainingColumn<C extends Any> = C extends Computed.Any
   : {
     [Property in C["name"]]: Stored.GetValue<C>
   }
+
+/**
+ * Converts a column type to a nullable column type
+ */
+export type MakeNullable<C extends Any> = C extends Stored.Any
+  ? Stored.MakeNullable<C>
+  : C extends Computed.Any ? Computed.MakeNullable<C>
+  : never


### PR DESCRIPTION
Left joins are useful for relations that may not exist. For example, in this case, we have a many-to-many relationship between cats and the humans that take care of them. If we want to query all cats and their human owners while including cats that have no human owners, we need to use a left join.

In this case, all the columns in the "right" table ("catOwners" and "humans") will potentially be null.

```ts
const cats = await db.query(
    dbSchema.query()
      .from("cats")
      .leftJoin(
        "catOwners",
        (t) => t.column("cats", "id").eq(t.column("catOwners", "petId")),
      )
      .leftJoin(
        "humans",
        (t) => t.column("humans.id").eq(t.column("catOwners.ownerId")),
      )
      .select({
        catName: (t) => t.column("cats.name"),
        owner: (t) => t.column("humans.firstName"),
      }),
  ).toArray()
```